### PR TITLE
First pass at highlighting the current locale

### DIFF
--- a/public/css/menu.less
+++ b/public/css/menu.less
@@ -2,6 +2,10 @@
 {
   display: inline-block;
   margin-left: 20px;
+  .apos-button--group
+  {
+    border: 0px;
+  }
   .apos-button
   {
     margin-left: 5px;
@@ -22,12 +26,20 @@
   }
   &.apos-workflow-modified.apos-workflow-committable
   {
+    .apos-button--group
+    {
+      border: 2px solid;
+    }
     [data-apos-workflow-commit] {
       display: inline-block;
     }
   }
   &.apos-workflow-unsubmitted
   {
+    .apos-button--group
+    {
+      border: 2px solid;
+    }
     [data-apos-workflow-submit] {
       display: inline-block;
     }

--- a/public/css/user.less
+++ b/public/css/user.less
@@ -126,6 +126,14 @@
     .apos-workflow-locale-input--disabled > .apos-workflow-locale-label {
       opacity: 0.7;
     }
+    .apos-workflow-locale-control-label--committed {
+      font-weight: bold;
+      small {
+        color: @apos-mid;
+        font-size: 0.8em;
+        font-weight: normal;
+      }
+    }
   }
 }
 

--- a/views/export-modal.html
+++ b/views/export-modal.html
@@ -28,7 +28,8 @@
     'locales',
     [
       {
-        name: 'locale'
+        name: 'locale',
+        commitLocale: data.commit.locale
       }
     ],
     data.nestedLocales)

--- a/views/locale-tree.html
+++ b/views/locale-tree.html
@@ -14,10 +14,19 @@
             {# Checkbox is default control type #}
             <input{% if locale.disabled %} disabled{% endif %} class="apos-workflow-locale-input" type="checkbox" id="{{ prefix }}[{{ locale.name }}{{ control.suffix }}]" name="{{ prefix }}[{{ locale.name }}{{ control.suffix }}]" value="1" />
             <span class="apos-workflow-locale-checkbox-indicator"></span>
-            <label for="{{ prefix }}[{{ locale.name }}{{ control.suffix }}]" class="apos-workflow-locale-control-label">{{ control.label }}</label>
+            {%- if locale.name === control.commitLocale %}
+              <label for="{{ prefix }}[{{ locale.name }}{{ control.suffix }}]" class="apos-workflow-locale-control-label apos-workflow-locale-control-label--committed">
+                {{ control.label }}
+                <span class="apos-workflow-locale-label">{{ locale.label or locale.name }}&nbsp;<small>(committed)</small></span>
+              </label>
+            {%- else %}
+              <label for="{{ prefix }}[{{ locale.name }}{{ control.suffix }}]" class="apos-workflow-locale-control-label">
+                {{ control.label }}
+                <span class="apos-workflow-locale-label">{{ locale.label or locale.name }}</span>
+              </label>
+            {%- endif %}
           {% endif %}
         {% endfor %}
-        <span class="apos-workflow-locale-label">{{ locale.label or locale.name }}</span>
         {%- if locale.children -%}
           {{ tree(prefix, controls, locale.children) }}
         {%- endif -%}


### PR DESCRIPTION
A couple things:
1. Is this the best way to highlight this item? Maybe a checkmark icon to the right of the locale name would also be good.
2. This should probably be refactored into a macro. Note if you agree.
3. I also placed the text inside the label tag so it's clickable.

Here's the current appearance with this PR:
<img width="506" alt="apostrophe_sandbox__home" src="https://user-images.githubusercontent.com/116818/28730099-c87a7706-739c-11e7-9fcd-c12bdfe977bc.png">


For reference Michelin ticket: https://git.dgadteamdev.com/pa/apostrophe-enhancements/issues/72