### PR TITLE
Added a notification feedback to the user

### DIFF
--- a/lib/modules/apostrophe-workflow-pages/public/js/editor.js
+++ b/lib/modules/apostrophe-workflow-pages/public/js/editor.js
@@ -16,6 +16,7 @@ apos.define('apostrophe-pages-editor', {
       });
       self.link('apos-workflow-commit', function() {
         self.committing = true;
+        apos.notify('The page has been created and saved.', { type: 'success' });
         return self.save(function(err) {
           if (err) {
             self.committing = false;


### PR DESCRIPTION
Note: I didn't need to add notification feedback to the 'submit' selection, because clicking that from the workflow dialog immediately closes the modal. The difference is that when you click on 'commit' you get a secondary modal where you can "Cancel." This feedback clarifies the fact that the page has already been created and saved, and therefore when you click "Cancel" on this secondary modal you are only cancelling the commit action and not the page creation.