### PR TITLE
exports should patch individual widget properties rather than forcing…

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -961,11 +961,11 @@ module.exports = function(self, options) {
       }
       var deleteAfter = false;
       // Modified. Could also be moved, so don't return
-      if (JSON.stringify(value) !== JSON.stringify(toObjects.byId[value._id])) {
+      if (!_.isEqual(value, toObjects.byId[value._id])) {
         if (description) {
           description.push({ change: 'modified', _id: value._id, value: value });
         } else {
-          updateObject(draft, draftObjects, originalFrom[value._id]);
+          updateObject(draft, draftObjects, toObjects.byId[value._id], value, originalFrom[value._id]);
         }
         // So we know the difference no longer exists when examining
         // a parent object
@@ -1114,10 +1114,19 @@ module.exports = function(self, options) {
       });
     }
 
-    function updateObject(context, objects, object) {
-      var dotPath = objects.dotPaths[object._id];
+    function updateObject(context, objects, oldObject, newObject, originalNewObject) {
+      // Try to patch rather than copying in a way that would
+      // crush intended differences at the subwidget level
+      var dotPath = objects.dotPaths[oldObject._id];
       if (dotPath) {
-        deep(context, dotPath, object);
+        try {
+          var patch = diff.diff(oldObject, newObject);
+          var targetObject = deep(context, dotPath);
+          diff.patch(targetObject, patch);
+        } catch (e) {
+          console.error(e);
+          deep(context, dotPath, originalNewObject);
+        }
       }
     }
     

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -116,10 +116,14 @@ module.exports = function(self, options) {
           });
         }
 
-        // Resolve relationship ids to point to the locale the patch is coming from,
-        // so that the diff applies properly
+        // Resolve relationship ids in the "from" document (which will have
+        // been in a draft locale) and in the "draft" document (where we are
+        // exporting to) to point to a consistent locale, so that the diff applies properly
         function resolveToSource(callback) {
-          return self.resolveRelationships(req, draft, to.workflowLocale, callback);
+          return async.series([
+            _.partial(self.resolveRelationships, req, draft, to.workflowLocale),
+            _.partial(self.resolveRelationships, req, from, to.workflowLocale)
+          ], callback);
         }
 
         function applyPatch(callback) {
@@ -139,7 +143,7 @@ module.exports = function(self, options) {
               success.push(self.liveify(locale));
             }
             return callback(null);
-          });          
+          });
 
         }
 
@@ -147,6 +151,7 @@ module.exports = function(self, options) {
         function resolveToDestination(callback) {
           return self.resolveRelationships(req, draft, draft.workflowLocale, callback);
         }
+
         function update(callback) {
           draft.workflowSubmitted = self.getWorkflowSubmittedProperty(req, { type: 'exported' });
           return self.apos.docs.update(req, draft, callback);


### PR DESCRIPTION
… a copy of the entire widget, even if the properties are not subwidgets. Also, joins were being exported every time due to the absence of a resolveRelationships call for "from" during export