### PR TITLE
preview deleted parent widgets properly. We need to send the browser …

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -915,7 +915,7 @@ module.exports = function(self, options) {
         }
       }
     });
-        
+
     // Step 1: find all the sub-objects with an _id property that are
     // present in the docs and sort them in descending order by
     // depth. These will be schema array items and widgets

--- a/lib/api.js
+++ b/lib/api.js
@@ -886,7 +886,7 @@ module.exports = function(self, options) {
   // This array is intended to facilitate previewing, not as a patch format.
 
   self.applyPatch = function(to, from, draft, callback) {
-
+    
     var description;
 
     if (Array.isArray(draft)) {
@@ -915,22 +915,28 @@ module.exports = function(self, options) {
         }
       }
     });
-    
+        
     // Step 1: find all the sub-objects with an _id property that are
     // present in the docs and sort them in descending order by
     // depth. These will be schema array items and widgets
 
     var fromObjects = getObjects(from);
+    var toObjects = getObjects(to);
+
     var originalFrom = {};
+    var originalTo = {};
 
     // Clone the original objects so that if we remove already patched subproperties to
     // avoid false positives for parent objects, we still get a complete patch if
     // a parent object *does* get modified in a property native to it
+
     _.each(fromObjects.objects, function(object) {
       originalFrom[object._id] = _.cloneDeep(object);
     });
+    _.each(toObjects.objects, function(object) {
+      originalTo[object._id] = _.cloneDeep(object);
+    });
 
-    var toObjects = getObjects(to);
     var draftObjects = draft && getObjects(draft);
                 
     // Step 2: iterate over those objects, patching directly as appropriate
@@ -943,7 +949,7 @@ module.exports = function(self, options) {
         if (description) {
           description.push({
             _id: value._id,
-            value: value,
+            value: originalTo[value._id],
             dotPath: toObjects.dotPaths[value._id],
             change: 'removed'
           });

--- a/lib/api.js
+++ b/lib/api.js
@@ -886,7 +886,7 @@ module.exports = function(self, options) {
   // This array is intended to facilitate previewing, not as a patch format.
 
   self.applyPatch = function(to, from, draft, callback) {
-    
+
     var description;
 
     if (Array.isArray(draft)) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1005,7 +1005,7 @@ module.exports = function(self, options) {
   });
   
   self.route('post', 'diff', function(req, res) {
-    
+
     if (!req.user) {
       // Confusion to the enemy
       return res.status(404).send('not found');

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1005,7 +1005,7 @@ module.exports = function(self, options) {
   });
   
   self.route('post', 'diff', function(req, res) {
-
+    
     if (!req.user) {
       // Confusion to the enemy
       return res.status(404).send('not found');


### PR DESCRIPTION
…the original version of the parent widget, before subwidgets were pruned out of it in an effort to determine whether there were modifications beyond that or not. Otherwise the preview will look weird or even crash if the template is not tolerant.