### PR TITLE
update the submit and commit buttons only on page load and actual cha…

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -78,7 +78,8 @@ module.exports = function(self, options) {
       'viewUsersRemovedIds',
       'viewGroupsRemovedIds',
       'editUsersRemovedIds',
-      'editGroupsRemovedIds'
+      'editGroupsRemovedIds',
+      'advisoryLock'
     ];
     
     // Attachment fields themselves are not directly localized (they are not docs)

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -47,6 +47,15 @@ apos.define('apostrophe-workflow', {
         });
       });
       self.updateWorkflowControls();
+      apos.on('areaEdited', function() {
+        self.updateWorkflowControls();
+      });
+      apos.on('workflowCommitted', function() {
+        self.updateWorkflowControls();
+      });
+      apos.on('workflowSubmitted', function() {
+        self.updateWorkflowControls();
+      });
     };
     
     self.updateWorkflowControls = function() {
@@ -80,7 +89,6 @@ apos.define('apostrophe-workflow', {
           }
         });
 
-        setTimeout(self.updateWorkflowControls, 1000);
         function setClass($menu, c, flag) {
           if (flag) {
             $menu.addClass(c);
@@ -272,6 +280,7 @@ apos.define('apostrophe-workflow', {
           apos.notify('An error occurred submitting the document for approval.', { type: 'error' });
           return callback && callback('error');
         } else {
+          return apos.emit('workflowSubmitted', ids);
           apos.notify('Your submission will be reviewed.', { type: 'success', dismiss: true });
           return callback && callback(null);
         }
@@ -310,6 +319,9 @@ apos.define('apostrophe-workflow', {
         i++;
         return self.launchCommitModal({ id: id, index: i, total: ids.length, lead: (leadId == id) }, callback);
       }, function(err) {
+        if (!err) {
+          return apos.emit('workflowCommitted', ids);
+        }
         return callback && callback(err);
       });
     };


### PR DESCRIPTION
…nges, greatly reducing network traffic and server stress. Also, ignore the advisoryLock property for purposes of calculating diffs, otherwise we get lots of false positives for commits.