### PR TITLE
fixed two ux problems. One: if the parent widget was just added to th…

### DIFF
--- a/public/js/force-export-widget-modal.js
+++ b/public/js/force-export-widget-modal.js
@@ -7,6 +7,13 @@ apos.define('apostrophe-workflow-force-export-widget-modal', {
   source: 'force-export-widget-modal',
   
   verb: 'force-export-widget',
+
+  construct: function(self, options) {
+    // Can't be done in the same way because we don't send a commit id
+    self.exportRelatedUnexported = function(locales, callback) {
+      return setImmediate(callback);
+    };
+  }
   
   // The base class already sends everything in options.body so no
   // further modifications are needed on the front end so far

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -246,7 +246,8 @@ apos.define('apostrophe-workflow', {
     self.enableForceExportWidget = function() {
       apos.ui.link('apos-workflow-force-export-widget', null, function($el) {
         var widgetId = $el.closest('[data-apos-widget-id]').attr('data-apos-widget-id');
-        var docId = $el.closest('[data-doc-id]').attr('data-doc-id');
+        // Skip up to the enclosing area with a real doc id, not a virtual or widget one
+        var docId = $el.closest('[data-doc-id^="c"]').attr('data-doc-id');
         return apos.areas.saveAllIfNeeded(function() {
           return apos.create('apostrophe-workflow-force-export-widget-modal', 
             _.assign({


### PR DESCRIPTION
…e page, force-exporting a child widget fails without a clear message. Two: force exporting a widget should not trigger the standard export-related mechanism (at the very least it would require modification and as-is it fails leaving the dialog up).