### PR TITLE
Dgad 39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.3.3
+
+Unit tests passing.
+
+Regression tests passing.
+
+* Safely ignore widgets with no manager.
+* When autoconfiguring the `hostnames` feature based on the legacy `subdomains` setting, keep port numbers unless they are `80` or `443`.
+* Override `getBaseUrl` method of `apostrophe-pages` to push out the right absolute URLs based on the hostnames option.
+
 ## 2.3.2
 
 Unit tests passing.

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -210,8 +210,13 @@ module.exports = function(self, options) {
       widgets = widgets.concat(area.items);
     });
     var joins = [];
-    widgets = _.filter(widgets, function(widget) {
-      var schema = self.apos.areas.getWidgetManager(widget.type).schema;
+    _.each(widgets, function(widget) {
+      var manager = self.apos.areas.getWidgetManager(widget.type);
+      if (!manager) {
+        // We already warn about obsolete widgets elsewhere, don't crash
+        return;
+      }
+      schema = manager.schema;
       joins = joins.concat(self.findJoinsInSchema(widget, schema));
     });
     return joins;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -26,7 +26,10 @@ module.exports = function(self, options) {
         subdomain = matches[1];
         domain = matches[3];
         if (!_.has(self.locales, subdomain)) {
-          domain = host.replace(/\:\d+$/, '');
+          domain = host;
+          if (domain.match(/(\:80|\:443)$/)) {
+            domain = domain.replace(/\:\d+$/, '');
+          }
         }
         _.each(self.locales, function(locale, name) {
           if (!name.match(/-draft$/)) {

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -291,6 +291,20 @@ module.exports = {
       }, callback);
     };
     
+    var superGetBaseUrl = self.getBaseUrl;
+    // Return the appropriate base URL for constructing absolute
+    // URLs in the relevant locale, if the `hostnames` option is
+    // in play for this locale, otherwise fall back to the
+    // standard behavior
+    self.getBaseUrl = function(req) {
+      var workflow = self.apos.modules['apostrophe-workflow'];
+      var live = workflow.liveify(req.locale || workflow.defaultLocale);
+      if (!(workflow.hostnames && workflow.hostnames[live])) {
+        return superGetBaseUrl(req);
+      }
+      return req.protocol + '://' + workflow.hostnames[live];
+    };
+
   }
 
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-workflow",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Workflow, approvals, localization and internationalization for Apostrophe 2.x",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
* Safely ignore widgets with no manager.
* When autoconfiguring the `hostnames` feature based on the legacy `subdomains` setting, keep port numbers unless they are `80` or `443`.
* Override `getBaseUrl` method of `apostrophe-pages` to push out the right absolute URLs based on the hostnames option.
