### PR TITLE
batch operations for submit, commit+export, and force export of piece…

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -174,6 +174,8 @@ module.exports = function(self, options) {
     }, callback);
   };
 
+  // You probably want `commitLatest`. 
+  //
   // Commit a doc from one locale to another. `from` and `to` should
   // be the doc as found in each of the locales. The callback receives
   // `(null, commitId)` where `commitId` is a unique identifier for
@@ -1407,6 +1409,299 @@ module.exports = function(self, options) {
       $and: [ criteria, self.apos.permissions.criteria(req, 'edit-' + doc.type) ]
     };
     return criteria;
+  };
+  
+  // Commits the current draft of the given doc id
+  // to the live locale for that document. `id`
+  // may be either the draft or the live id.
+  // On success, reports `(null, commitId, draftTitle)`
+  // to the callback.
+  //
+  // The `id` argument is sanitized, so it is safe
+  // to pass user input directly.
+  
+  self.commitLatest = function(req, id, callback) {
+    if (!req.user) {
+      // confusion to the enemy
+      return callback('error');
+    }
+    var id = self.apos.launder.id(id);
+    var draft, live, commitId;
+    return async.series({
+      getDraftAndLive,
+      commit
+    }, function(err) {
+      if (err) {
+        return callback(err);
+      }
+      return callback(null, commitId, draft.title);
+    });
+    function getDraftAndLive(callback) {
+      return self.getDraftAndLive(req, id, {}, function(err, _draft, _live) {
+        if (err) {
+          return callback(err);
+        }
+        draft = _draft;
+        live = _live;
+        return callback(null, draft, live);
+      });
+    }
+    function commit(callback) {
+      return self.commit(req, draft, live, function(err, _commitId) {
+        commitId = _commitId;
+        return callback(err);
+      });
+    }
+  };  
+  
+  // Export the given commit id (NOT doc id) to the given locales.
+  // On success the callback receives `(null, result)`
+  // where `result` is an object with `success` and `errors` properties.
+  // `success` is an array of locale names, `errors` is
+  // an array of objects with `locale` and `message` properties.
+  //
+  // Note that failure to export to a locale does not result
+  // in an error as the first argument to the callback as this may occur
+  // in normal situations such as a document too different
+  // to calculate a diff against.
+  //
+  // This method validates both `id` and `locales`, so
+  // it is acceptable to pass user input directly.
+
+  self.export = function(req, id, locales, callback) {
+
+    if (!req.user) {
+      // Confusion to the enemy
+      return callback('error');
+    }
+    
+    var id = self.apos.launder.id(id);
+
+    if (Array.isArray(locales)) {
+      locales = _.filter(locales, function(locale) {
+        return ((typeof(locale) === 'string') && (_.has(self.locales, locale)));
+      });
+    }
+    locales = _.map(locales, function(locale) {
+      return self.draftify(locale);
+    });
+    
+    var success = [];
+    var errors = [];
+    var commit;
+
+    return async.series({
+      getCommit,
+      applyPatches
+    }, function(err) {
+      if (err) {
+        return callback(err);
+      }
+      return callback(null, {
+        success: success,
+        errors: errors
+      });
+    });
+
+    function getCommit(callback) {
+      return self.findDocAndCommit(req, id, function(err, doc, _commit) {
+        if (err) {
+          return callback(err);
+        }
+        commit = _commit;
+        locales = _.filter(locales, function(locale) {
+          // Reapplying to source locale doesn't make sense
+          return (locale !== commit.from.workflowLocale);
+        });
+        if (!commit) {
+          return callback('notfound');
+        }
+        return callback(null);
+      });
+    }
+
+    function applyPatches(callback) {
+
+      return async.eachSeries(locales, function(locale, callback) {
+
+        var draft, from, to;
+
+        from = _.cloneDeep(commit.from);
+        to = _.cloneDeep(commit.to);
+        
+        return async.series([ getDraft, resolveToSource, applyPatch, resolveToDestination, update ], callback);
+
+        function getDraft(callback) {
+          return self.findDocs(req, { workflowGuid: commit.workflowGuid }, locale).toObject(function(err, _draft) {
+            if (err) {
+              return callback(err);
+            }
+            if (!(_draft && _draft._edit)) {
+              return callback('no draft');
+            }
+            draft = _draft;
+            return callback(null);
+          });
+        }
+
+        // Resolve relationship ids in the "from" document (which will have
+        // been in a draft locale) and in the "draft" document (where we are
+        // exporting to) to point to a consistent locale, so that the diff applies properly
+        function resolveToSource(callback) {
+          return async.series([
+            _.partial(self.resolveRelationships, req, draft, to.workflowLocale),
+            _.partial(self.resolveRelationships, req, from, to.workflowLocale)
+          ], callback);
+        }
+
+        function applyPatch(callback) {
+
+          self.deleteExcludedProperties(from);
+          self.deleteExcludedProperties(to);
+
+          if (!draft) {
+            errors.push({ locale: self.liveify(locale), message: 'not found, run task' });
+            return callback(null);
+          }
+          
+          return self.applyPatch(to, from, draft, function(err) {
+            if (err) {
+              errors.push({ locale: self.liveify(locale), message: 'Some or all content was too different' });
+            } else {
+              draft.workflowImportedFrom = draft.workflowImportedFrom || {};
+              draft.workflowImportedFrom[self.liveify(req.locale)] = new Date();
+              success.push(self.liveify(locale));
+            }
+            return callback(null);
+          });
+
+        }
+
+        // Resolve relationship ids back to the locale the draft is coming from
+        function resolveToDestination(callback) {
+          return self.resolveRelationships(req, draft, draft.workflowLocale, callback);
+        }
+
+        function update(callback) {
+          draft.workflowSubmitted = self.getWorkflowSubmittedProperty(req, { type: 'exported' });
+          return self.apos.docs.update(req, draft, callback);
+        }
+      }, callback);
+    }
+  };  
+  
+  // Force export the doc with the given id to the given locales.
+  // the id and locales arguments are sanitized, so it is safe
+  // to pass user input directly.
+  //
+  // On success the callback receives `(null, results)` where
+  // `results` is an object with `success` and `errors` properties.
+  // `success` is an array of locale names, and `errors` is
+  // an array of objects with `locale` and `message` properties.
+  // Note that failure to export to a single locale is not an
+  // overall error because it can be a normal situation and
+  // does not indicate a systemic problem (TODO: is this
+  // really true for this method in the same way it is true for export?)
+  
+  self.forceExport = function(req, id, locales, callback) {
+    if (!req.user) {
+      // Confusion to the enemy
+      return callback('error');
+    }
+    var id = self.apos.launder.id(id);
+    var success = [];
+    var errors = [];
+    var drafts, original;
+    if (Array.isArray(locales)) {
+      locales = _.filter(locales, function(locale) {
+        return ((typeof(locale) === 'string') && (_.has(self.locales, locale)));
+      });
+    }
+    locales = _.map(locales, function(locale) {
+      return self.draftify(locale);
+    });
+    return async.series({
+      getOriginal,
+      applyPatches
+    }, function(err) {
+      if (err) {
+        return callback(err);
+      }
+      return callback(null, {
+        success: success,
+        errors: errors
+      });
+    });
+
+    function getOriginal(callback) {
+      return self.findDocs(req, { _id: id }).toObject(function(err, doc) {
+        if (err) {
+          return callback(err);
+        }
+        if ((!doc) || (!doc._edit)) {
+          return callback('notfound');
+        }
+        original = self.apos.utils.clonePermanent(doc);
+        locales = _.filter(locales, function(locale) {
+          // Reapplying to source locale doesn't make sense
+          return (locale !== original.workflowLocale);
+        });
+        return callback(null);
+      });
+    }
+
+    function applyPatches(callback) {
+
+      return async.eachSeries(locales, function(locale, callback) {
+
+        var resolvedOriginal, draft;
+        
+        // Our own modifiable copy to safely pass to `resolveToDestination`
+        resolvedOriginal = _.cloneDeep(original);
+
+        return async.series([ getDraft, resolveToDestination, applyPatch, update ], callback);
+
+        function getDraft(callback) {
+          return self.findDocs(req, { workflowGuid: resolvedOriginal.workflowGuid }, locale).toObject(function(err, _draft) {
+            if (err) {
+              return callback(err);
+            }
+            if (!(_draft && _draft._edit)) {
+              return callback('notfound');
+            }
+            draft = _draft;
+            return callback(null);
+          });
+        }
+
+        // Resolve relationship ids of resolved original to point to locale
+        // we're patching
+        function resolveToDestination(callback) {
+          return self.resolveRelationships(req, resolvedOriginal, draft.workflowLocale, callback);
+        }
+
+        function applyPatch(callback) {
+
+          if (!draft) {
+            errors.push({ locale: self.liveify(locale), message: 'not found, run task' });
+            return callback(null);
+          }
+
+          self.deleteExcludedProperties(resolvedOriginal);
+          
+          _.assign(draft, resolvedOriginal);
+          
+          return callback(null);
+                      
+        }
+
+        function update(callback) {
+          success.push(self.liveify(draft.workflowLocale));
+          return self.apos.docs.update(req, draft, callback); 
+        }
+
+      }, callback);
+    }     
   };
 
 };

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -9,6 +9,8 @@ module.exports = function(self, options) {
     self.pushAsset('script', 'locale-picker-modal', { when: 'user' });
     self.pushAsset('script', 'force-export-widget-modal', { when: 'user' });
     self.pushAsset('script', 'force-export-modal', { when: 'user' });
+    self.pushAsset('script', 'batch-export-modal', { when: 'user' });
+    self.pushAsset('script', 'batch-force-export-modal', { when: 'user' });
     self.pushAsset('stylesheet', 'user', { when: 'user' });
   };  
 };

--- a/lib/modules/apostrophe-workflow-pieces/index.js
+++ b/lib/modules/apostrophe-workflow-pieces/index.js
@@ -7,6 +7,39 @@ module.exports = {
 
   canEditTrash: true,
   
+  beforeConstruct: function(self, options) {
+
+    function onlyIf(type) {
+      return self.apos.modules['apostrophe-workflow'].includeType(type);
+    }
+
+    options.addBatchOperations = [
+      {
+        name: 'submit',
+        route: 'apostrophe-workflow:submit',
+        label: 'Submit',
+        buttonLabel: 'Submit',
+        onlyIf: onlyIf
+      },
+      {
+        name: 'commit',
+        route: 'apostrophe-workflow:batch-commit',
+        label: 'Commit',
+        buttonLabel: 'Commit',
+        onlyIf: onlyIf
+      },
+      {
+        name: 'force-export',
+        route: 'apostrophe-workflow:batch-force-export',
+        label: 'Force Export',
+        buttonLabel: 'Force Export',
+        onlyIf: onlyIf,
+        apiModule: 'apostrophe-workflow'
+      }
+    ].concat(options.addBatchOperations || []);
+
+  },
+  
   construct: function(self, options) {
     
     var superGetEditControls = self.getEditControls;

--- a/lib/modules/apostrophe-workflow-pieces/public/js/manager-modal.js
+++ b/lib/modules/apostrophe-workflow-pieces/public/js/manager-modal.js
@@ -1,0 +1,41 @@
+apos.define('apostrophe-pieces-manager-modal', {
+
+  construct: function(self, options) {
+
+    var workflow = apos.modules['apostrophe-workflow'];
+
+    self.batchSubmit = function() {
+      return self.batchSimple(
+        'submit',
+        "Are you sure you want to submit " + self.choices.length + " item(s)?",
+        {}
+      );
+    };
+
+    self.batchCommit = function() {
+      return self.batchSimple(
+        'commit',
+        "Are you sure you want to commit " + self.choices.length + " item(s)?",
+        {
+          success: function(result, callback) {
+            return workflow.batchExport(result.commitIds, callback);
+          }
+        }
+      );
+    };
+
+    self.batchForceExport = function() {
+      return self.batchSimple(
+        'force-export',
+        "Are you sure you want to force export " + self.choices.length + " item(s)?",
+        {
+          dataSource: workflow.batchForceExportGetLocales,
+          success: function(result, callback) {
+            workflow.presentBatchExportResult(result);
+            return callback(null);
+          }
+        }
+      );
+    };
+  }
+});

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -4,186 +4,77 @@ var deep = require('deep-get-set');
 
 module.exports = function(self, options) {
   self.route('post', 'commit', function(req, res) {
-    if (!req.user) {
-      // Confusion to the enemy
-      return res.status(404).send('not found');
-    }
-    var id = self.apos.launder.id(req.body.id);
-    var draft, live, commitId;
-    return async.series({
-      getDraftAndLive,
-      commit
-    }, function(err) {
+    return self.commitLatest(req, req.body.id, function(err, commitId, title) {
       if (err) {
         console.error(err);
         return res.send({ status: 'error' });
       }
-      return res.send({ status: 'ok', commitId: commitId, title: draft.title });
+      return res.send({ status: 'ok', commitId: commitId, title });
     });
-    function getDraftAndLive(callback) {
-      return self.getDraftAndLive(req, id, {}, function(err, _draft, _live) {
-        if (err) {
-          return callback(err);
-        }
-        draft = _draft;
-        live = _live;
-        return callback(null, draft, live);
-      });
-    }
-    function commit(callback) {
-      return self.commit(req, draft, live, function(err, _commitId) {
-        commitId = _commitId;
-        return callback(err);
-      });
-    }
   });
-
-  self.route('post', 'export', function(req, res) {
-
-    if (!req.user) {
-      // Confusion to the enemy
-      return res.status(404).send('not found');
-    }
-
-    var id = self.apos.launder.id(req.body.id);
-    var locales = [];
-    var success = [];
-    var errors = [];
-    var drafts;
-    if (Array.isArray(req.body.locales)) {
-      locales = _.filter(req.body.locales, function(locale) {
-        return ((typeof(locale) === 'string') && (_.has(self.locales, locale)));
-      });
-    }
-    locales = _.map(locales, function(locale) {
-      return self.draftify(locale);
-    });
-
-    var commit;
-
-    return async.series({
-      getCommit,
-      applyPatches
-    }, function(err) {
-      if (err) {
-        console.error(err);
-        return res.send({ status: 'error' });
-      }
-      // Here the `errors` object has locales as keys and strings as values; these can be
-      // displayed or, since they are technical, just flagged as locales to which the patch
-      // could not be successfully applied
-      return res.send({ status: 'ok', success: success, errors: errors });
-    });
-
-    function getCommit(callback) {
-      return self.findDocAndCommit(req, id, function(err, doc, _commit) {
+  
+  self.route('post', 'batch-commit', function(req, res) {
+    var ids = self.apos.launder.ids(req.body.ids);
+    var commitIds = [];
+    return async.eachSeries(ids, function(id, callback) {
+      return self.commitLatest(req, id, function(err, commitId) {
         if (err) {
-          return callback(err);
+          console.error(err);
+          return res.send({ status: 'error' });
         }
-        commit = _commit;
-        locales = _.filter(locales, function(locale) {
-          // Reapplying to source locale doesn't make sense
-          return (locale !== commit.from.workflowLocale);
-        });
-        if (!commit) {
-          return callback('notfound');
-        }
+        commitIds.push(commitId);
         return callback(null);
       });
-    }
-
-    function applyPatches(callback) {
-
-      return async.eachSeries(locales, function(locale, callback) {
-
-        var draft, from, to;
-
-        from = _.cloneDeep(commit.from);
-        to = _.cloneDeep(commit.to);
-        
-        return async.series([ getDraft, resolveToSource, applyPatch, resolveToDestination, update ], callback);
-
-        function getDraft(callback) {
-          return self.findDocs(req, { workflowGuid: commit.workflowGuid }, locale).toObject(function(err, _draft) {
-            if (err) {
-              return callback(err);
-            }
-            if (!(_draft && _draft._edit)) {
-              return callback('no draft');
-            }
-            draft = _draft;
-            return callback(null);
-          });
+    }, function(err) {
+      if (err) {
+        console.error(err);
+        return res.send({ status: 'error' });
+      }
+      return res.send({ status: 'ok', commitIds: commitIds });
+    });
+  });
+  
+  self.route('post', 'export', function(req, res) {
+    var id = self.apos.launder.id(req.body.id);
+    return self.export(req, id, req.body.locales, function(err, results) {
+      if (err) {
+        return res.send({
+          status: (typeof(err) === 'string') ? err : 'error'
+        });
+      }
+      return res.send(_.assign({
+        status: 'ok'
+      }, results[id]));
+    });
+  });
+  
+  self.route('post', 'batch-export', function(req, res) {
+    var ids = self.apos.launder.ids(req.body.ids);
+    var results = {};
+    return async.eachSeries(ids, function(id, callback) {
+      return self.export(req, id, req.body.locales, function(err, result) {
+        if (err) {
+          return callback(err);
         }
-
-        // Resolve relationship ids in the "from" document (which will have
-        // been in a draft locale) and in the "draft" document (where we are
-        // exporting to) to point to a consistent locale, so that the diff applies properly
-        function resolveToSource(callback) {
-          return async.series([
-            _.partial(self.resolveRelationships, req, draft, to.workflowLocale),
-            _.partial(self.resolveRelationships, req, from, to.workflowLocale)
-          ], callback);
-        }
-
-        function applyPatch(callback) {
-
-          self.deleteExcludedProperties(from);
-          self.deleteExcludedProperties(to);
-
-          if (!draft) {
-            errors.push({ locale: self.liveify(locale), message: 'not found, run task' });
-            return callback(null);
-          }
-          
-          return self.applyPatch(to, from, draft, function(err) {
-            if (err) {
-              errors.push({ locale: self.liveify(locale), message: 'Some or all content was too different' });
-            } else {
-              draft.workflowImportedFrom = draft.workflowImportedFrom || {};
-              draft.workflowImportedFrom[self.liveify(req.locale)] = new Date();
-              success.push(self.liveify(locale));
-            }
-            return callback(null);
-          });
-
-        }
-
-        // Resolve relationship ids back to the locale the draft is coming from
-        function resolveToDestination(callback) {
-          return self.resolveRelationships(req, draft, draft.workflowLocale, callback);
-        }
-
-        function update(callback) {
-          draft.workflowSubmitted = self.getWorkflowSubmittedProperty(req, { type: 'exported' });
-          return self.apos.docs.update(req, draft, callback);
-        }
-      }, callback);
-    }
+        results[id] = result;
+        return callback(null);
+      });
+    }, function(err) {
+      if (err) {
+        return res.send({
+          status: (typeof(err) === 'string') ? err : 'error'
+        });
+      }
+      return res.send(_.assign({
+        status: 'ok'
+      }, {
+        results: results
+      }));
+    });
   });
   
   self.route('post', 'force-export', function(req, res) {
-    if (!req.user) {
-      // Confusion to the enemy
-      return res.status(404).send('not found');
-    }
-    var id = self.apos.launder.id(req.body.id);
-    var locales = [];
-    var success = [];
-    var errors = [];
-    var drafts, original;
-    if (Array.isArray(req.body.locales)) {
-      locales = _.filter(req.body.locales, function(locale) {
-        return ((typeof(locale) === 'string') && (_.has(self.locales, locale)));
-      });
-    }
-    locales = _.map(locales, function(locale) {
-      return self.draftify(locale);
-    });
-    return async.series({
-      getOriginal,
-      applyPatches
-    }, function(err) {
+    return self.forceExport(req, req.body.id, req.body.locales, function(err, results) {
       if (err) {
         console.error(err);
         return res.send({ status: 'error' });
@@ -191,80 +82,49 @@ module.exports = function(self, options) {
       // Here the `errors` object has locales as keys and strings as values; these can be
       // displayed or, since they are technical, just flagged as locales to which the patch
       // could not be successfully applied
-      return res.send({ status: 'ok', success: success, errors: errors });
+      return res.send(_.assign({
+        status: 'ok'
+      }, results));
     });
+  });
 
-    function getOriginal(callback) {
-      return self.findDocs(req, { _id: id }).toObject(function(err, doc) {
+  self.route('post', 'batch-force-export', function(req, res) {
+    var ids = self.apos.launder.ids(req.body.ids);
+    var results = {};
+    return async.eachSeries(ids, function(id, callback) {
+      return self.forceExport(req, id, req.body.locales, function(err, result) {
         if (err) {
           return callback(err);
         }
-        if ((!doc) || (!doc._edit)) {
-          return callback('notfound');
-        }
-        original = self.apos.utils.clonePermanent(doc);
-        locales = _.filter(locales, function(locale) {
-          // Reapplying to source locale doesn't make sense
-          return (locale !== original.workflowLocale);
-        });
+        results[id] = result;
         return callback(null);
       });
-    }
-
-    function applyPatches(callback) {
-
-      return async.eachSeries(locales, function(locale, callback) {
-
-        var resolvedOriginal, draft;
-        
-        // Our own modifiable copy to safely pass to `resolveToDestination`
-        resolvedOriginal = _.cloneDeep(original);
-
-        return async.series([ getDraft, resolveToDestination, applyPatch, update ], callback);
-
-        function getDraft(callback) {
-          return self.findDocs(req, { workflowGuid: resolvedOriginal.workflowGuid }, locale).toObject(function(err, _draft) {
-            if (err) {
-              return callback(err);
-            }
-            if (!(_draft && _draft._edit)) {
-              return callback('notfound');
-            }
-            draft = _draft;
-            return callback(null);
-          });
-        }
-
-        // Resolve relationship ids of resolved original to point to locale
-        // we're patching
-        function resolveToDestination(callback) {
-          return self.resolveRelationships(req, resolvedOriginal, draft.workflowLocale, callback);
-        }
-
-        function applyPatch(callback) {
-
-          if (!draft) {
-            errors.push({ locale: self.liveify(locale), message: 'not found, run task' });
-            return callback(null);
-          }
-
-          self.deleteExcludedProperties(resolvedOriginal);
-          
-          _.assign(draft, resolvedOriginal);
-          
-          return callback(null);
-                      
-        }
-
-        function update(callback) {
-          success.push(self.liveify(draft.workflowLocale));
-          return self.apos.docs.update(req, draft, callback); 
-        }
-
-      }, callback);
-    }     
+    }, function(err) {
+      if (err) {
+        return res.send({
+          status: (typeof(err) === 'string') ? err : 'error'
+        });
+      }
+      return res.send(_.assign({
+        status: 'ok'
+      }, {
+        results: results
+      }));
+    });
+    return self.forceExport(req, req.body.id, req.body.locales, function(err, results) {
+      if (err) {
+        console.error(err);
+        return res.send({ status: 'error' });
+      }
+      // Here the `errors` object has locales as keys and strings as values; these can be
+      // displayed or, since they are technical, just flagged as locales to which the patch
+      // could not be successfully applied
+      return res.send(_.assign({
+        status: 'ok'
+      }, results));
+    });
   });
-
+    
   self.route('post', 'force-export-widget', function(req, res) {
     if (!req.user) {
       // Confusion to the enemy
@@ -980,6 +840,30 @@ module.exports = function(self, options) {
       return res.send(self.render(req, 'export-modal.html', { commit: commit, nestedLocales: nestedLocales }));
     });
   });
+  
+  self.route('post', 'batch-export-modal', function(req, res) {
+    if (!req.user) {
+      // Confusion to the enemy
+      return res.status(404).send('not found');
+    }
+    // commit ids
+    var ids = self.apos.launder.ids(req.body.ids);
+    if (!ids.length) {
+      return res.status(404).send('not found');
+    }
+    // Use the first doc as a representative example
+    return self.findDocAndCommit(req, ids[0], function(err, doc, commit) {
+      if (err) {
+        console.error(err);
+        return res.status(500).send('error');
+      }
+      if (!commit) {
+        return res.send({ status: 'notfound' });
+      }
+      var nestedLocales = self.getEditableNestedLocales(req, doc);
+      return res.send(self.render(req, 'batch-export-modal.html', { ids: ids, locale: self.liveify(doc.workflowLocale), nestedLocales: nestedLocales }));
+    });
+  });
 
   self.route('post', 'force-export-widget-modal', function(req, res) {
     if (!req.user) {
@@ -1021,6 +905,29 @@ module.exports = function(self, options) {
       }
       var nestedLocales = self.getEditableNestedLocales(req, doc);
       return res.send(self.render(req, 'force-export-modal.html', { doc: doc, nestedLocales: nestedLocales }));
+    });
+  });
+
+  self.route('post', 'batch-force-export-modal', function(req, res) {
+    if (!req.user) {
+      // Confusion to the enemy
+      return res.status(404).send('not found');
+    }
+    var ids = self.apos.launder.ids(req.body.ids);
+    if (!ids.length) {
+      return res.status(404).send('not found');
+    }
+    // Representative example
+    return self.findDocs(req, { _id: ids[0] }).toObject(function(err, doc) {
+      if (err) {
+        console.error(err);
+        return res.status(500).send('error');
+      }
+      if (!(doc && doc._edit)) {
+        return res.status(404).send('notfound');
+      }
+      var nestedLocales = self.getEditableNestedLocales(req, doc);
+      return res.send(self.render(req, 'batch-force-export-modal.html', { ids: ids, locale: self.liveify(doc.workflowLocale), nestedLocales: nestedLocales }));
     });
   });
   

--- a/public/js/batch-export-modal.js
+++ b/public/js/batch-export-modal.js
@@ -1,0 +1,24 @@
+// A modal for exporting the changes in a given commit to other locales
+
+apos.define('apostrophe-workflow-batch-export-modal', {
+
+  extend: 'apostrophe-workflow-export-modal',
+
+  source: 'batch-export-modal',
+  
+  verb: 'batch-export',
+
+  construct: function(self, options) {
+
+    // Not a good idea for batch
+    self.exportRelatedUnexported = function(locales, callback) {
+      return callback(null);
+    };
+    
+    self.presentResult = function(result) {
+      var workflow = apos.modules['apostrophe-workflow'];
+      workflow.presentBatchExportResult(result);
+    };
+
+  }
+});

--- a/public/js/batch-force-export-modal.js
+++ b/public/js/batch-force-export-modal.js
@@ -1,0 +1,28 @@
+// A modal for force-exporting a group of docs
+// to other locales. Acts as a dataSource for
+// the force-export batch operation, does not
+// invoke the force export API on its own
+
+apos.define('apostrophe-workflow-batch-force-export-modal', {
+
+  extend: 'apostrophe-workflow-export-modal',
+
+  source: 'batch-force-export-modal',
+  
+  construct: function(self, options) {
+
+    self.saveContent = function(callback) {
+      var locales = self.getLocales();
+      if (!locales.length) {
+        apos.notify('Select at least one locale to export to.', { type: 'error' });
+        return callback('user');
+      }
+      // Modifying the `body` object passed to us
+      // by batchForceExportGetLocales allows that
+      // method to see the locales that were chosen
+      self.options.body.locales = locales;
+      return callback(null);
+    };
+
+  }
+});

--- a/public/js/export-modal.js
+++ b/public/js/export-modal.js
@@ -20,7 +20,7 @@ apos.define('apostrophe-workflow-export-modal', {
       return callback(null);
     };
 
-    self.saveContent = function(callback) {
+    self.getLocales = function() {
       var locales = [];
       var $checkboxes = self.$el.find('input[type="checkbox"]:checked');
       $checkboxes.each(function() {
@@ -30,6 +30,12 @@ apos.define('apostrophe-workflow-export-modal', {
           locales.push(matches[1]);
         }
       });
+      return locales;
+    };
+
+    self.saveContent = function(callback) {
+      var locales = self.getLocales();
+
       if (!locales.length) {
         apos.notify('Select at least one locale to export to.', { type: 'error' });
         return callback('user');
@@ -48,17 +54,21 @@ apos.define('apostrophe-workflow-export-modal', {
             apos.notify('An error occurred.', { type: 'error' });
             return callback(result.status);
           }
-          _.each(result.errors, function(error) {
-            apos.notify('%s: ' + error.message, error.locale, { type: 'error' });
-          });
-          if (result.success.length) {
-            apos.notify('Successfully exported to: %s', result.success.join(', '), { type: 'success', dismiss: true });
-          }
+          self.presentResult(result);
           return callback(null);
         }, function(err) {
           return callback(err);
         });
       });
+    };
+    
+    self.presentResult = function(result) {
+      _.each(result.errors, function(error) {
+        apos.notify('%s: ' + error.message, error.locale, { type: 'error' });
+      });
+      if (result.success.length) {
+        apos.notify('Successfully exported to: %s', result.success.join(', '), { type: 'success', dismiss: true });
+      }
     };
     
     self.exportRelatedUnexported = function(locales, callback) {

--- a/public/js/user.js
+++ b/public/js/user.js
@@ -215,8 +215,38 @@ apos.define('apostrophe-workflow', {
       return self.launchExportModal({ id: id }, callback);
     };
     
-    self.launchExportModal = function(options, callback) {
+    // ids are commit ids, not doc ids
+
+    self.batchExport = function(ids, callback) {
+      return self.launchBatchExportModal({ ids: ids }, callback);
+    };
+    
+    self.batchForceExportGetLocales = function(data, callback) {
+      return self.launchBatchForceExportModal(data, callback);
+    };
+
+    self.launchExportModal = function(data, callback) {
       return apos.create('apostrophe-workflow-export-modal', 
+        _.assign({}, self.options, {
+          manager: self,
+          body: data,
+          after: callback
+        }, options)
+      );
+    };
+
+    self.launchBatchExportModal = function(options, callback) {
+      return apos.create('apostrophe-workflow-batch-export-modal', 
+        _.assign({}, self.options, {
+          manager: self,
+          body: options,
+          after: callback
+        }, options)
+      );
+    };
+
+    self.launchBatchForceExportModal = function(options, callback) {
+      return apos.create('apostrophe-workflow-batch-force-export-modal', 
         _.assign({}, self.options, {
           manager: self,
           body: options,
@@ -242,6 +272,17 @@ apos.define('apostrophe-workflow', {
         );
       });
     };
+
+    self.launchBatchForceExportModal = function(options, callback) {
+      return apos.create('apostrophe-workflow-batch-force-export-modal', 
+        _.assign({}, self.options, {
+          manager: self,
+          body: options,
+          after: callback
+        }, options)
+      );
+    };
+
 
     self.enableForceExportWidget = function() {
       apos.ui.link('apos-workflow-force-export-widget', null, function($el) {
@@ -442,6 +483,28 @@ apos.define('apostrophe-workflow', {
       return apos.create(self.__meta.name + '-locale-picker-modal',
         _.assign({ manager: self, body: { workflowGuid: options.contextGuid } }, options)
       );
+    };
+    
+    self.presentBatchExportResult = function(result) {
+      var errors = 0;
+      var success = 0;
+      _.each(result.results, function(result, key) {
+        if (result.errors.length) {
+          errors++;
+        }
+        if (result.success.length) {
+          success++;
+        }
+      });
+      if (errors) {
+        apos.notify('Errors were encountered for some locales while exporting %s of the documents.', errors, { type: 'error' });
+      }
+      if (success) {
+        apos.notify('%s documents were successfully exported to one or more locales.', success, { type: 'success' });
+      }
+      if (!(errors || success)) {
+        apos.notify('No documents were exported.');
+      }
     };
     
     self.enableCrossDomainSessionToken = function() {

--- a/views/batch-export-modal.html
+++ b/views/batch-export-modal.html
@@ -1,0 +1,40 @@
+{%- extends "apostrophe-modal:base.html" -%}
+{%- import "apostrophe-modal:macros.html" as modals -%}
+{%- import "apostrophe-ui:components/buttons.html" as buttons with context -%}
+{%- import "locale-tree.html" as localeTree -%}
+
+{%- block modalClass -%}
+  apos-workflow-export-modal apos-ui-modal-no-sidebar
+{%- endblock -%}
+
+{%- block controls -%}
+  {{ buttons.minor('Skip', { action: 'cancel' }) }}
+  {{ buttons.major('Batch Export', { action: 'save' }) }}
+{%- endblock -%}
+
+{%- block label -%}
+  {{ __('Exporting changes for %s item(s) (%s)', data.ids.length, data.locale) }}
+{%- endblock -%}
+
+{% block instructions %}
+  <p>
+    {{ __('This change is already committed for the %s locale. To push this change to additional locales, select them below, then click Export. Selecting the %s locale may still be helpful to select sub-locales.', data.locale, data.locale) }}
+  </p>
+{% endblock %}
+
+{%- block body -%}
+<div class="apos-workflow-export-locales">
+  {{ localeTree.tree(
+    'locales',
+    [
+      {
+        name: 'locale',
+        commitLocale: data.locale
+      }
+    ],
+    data.nestedLocales)
+  }}
+</div>
+{%- endblock -%}
+
+{%- block footerContainer -%}{%- endblock -%}

--- a/views/batch-force-export-modal.html
+++ b/views/batch-force-export-modal.html
@@ -1,0 +1,39 @@
+{%- extends "apostrophe-modal:base.html" -%}
+{%- import "apostrophe-modal:macros.html" as modals -%}
+{%- import "apostrophe-ui:components/buttons.html" as buttons with context -%}
+{%- import "locale-tree.html" as localeTree -%}
+
+{%- block modalClass -%}
+  apos-workflow-export-modal apos-ui-modal-no-sidebar
+{%- endblock -%}
+
+{%- block controls -%}
+  {{ buttons.minor('Skip', { action: 'cancel' }) }}
+  {{ buttons.major('Export', { action: 'save' }) }}
+{%- endblock -%}
+
+{%- block label -%}
+  {{ __('Forcing export of %s item(s) (%s)', data.ids.length, data.locale) }}
+{%- endblock -%}
+
+{% block instructions %}
+  <p>
+    {{ __('You are forcing an export, which will copy the current draft(s) verbatim to other locales. Select them below, then click Export. Selecting the %s locale may still be helpful to select sub-locales.', data.locale, data.locale) }}
+  </p>
+{% endblock %}
+
+{%- block body -%}
+<div class="apos-workflow-export-locales">
+  {{ localeTree.tree(
+    'locales',
+    [
+      {
+        name: 'locale'
+      }
+    ],
+    data.nestedLocales)
+  }}
+</div>
+{%- endblock -%}
+
+{%- block footerContainer -%}{%- endblock -%}


### PR DESCRIPTION
…s. Factored out code from routes.js, creating a documented javascript API for the operations involved, so that batch routes can reuse it.