### PR TITLE
Missing locales logic was actually inserting in all locales, not just…

### DIFF
--- a/lib/callAll.js
+++ b/lib/callAll.js
@@ -74,7 +74,7 @@ module.exports = function(self, options) {
         return callback(null);
       }
       // A new doc needs to be brought into existence across all locales
-      return async.eachSeries(_.keys(self.locales), function(locale, callback) {
+      return async.eachSeries(missingLocales, function(locale, callback) {
 
         var _doc = self.apos.utils.clonePermanent(doc);
         if (locale === doc.workflowLocale) {

--- a/lib/modules/apostrophe-workflow-pages/index.js
+++ b/lib/modules/apostrophe-workflow-pages/index.js
@@ -242,9 +242,10 @@ module.exports = {
     // the locales and to adjust the slugs if the prefixes option
     // is in use
     self.implementParkAll = function(callback) {
-      if (self.apos.argv._[0] === 'apostrophe-workflow:add-missing-locales') {
+      if ((self.apos.argv._[0] === 'apostrophe-workflow:add-missing-locales') ||
+        (self.apos.argv._[0] === 'apostrophe-workflow:add-locale-prefixes')) {
         // If we park pages in this scenario, we'll wind up with
-        // duplicate pages in the new locales after add-missing-locales
+        // duplicate pages in the new locales after the task
         // fills them in
         return setImmediate(callback);
       }


### PR DESCRIPTION
… the locales that were missing. Also, do not attempt to park pages while running the add-locale-prefixes task. Although this may not have caused harm it is an unnecessary risk.

The missing locales logic bug was the cause of a recurrence of our old friend the duplicate parked pages bug, as reported in dgad-247.
